### PR TITLE
[Chore]: 로컬 임시 SSL 제거 및 uvicorn host 0.0.0.0 설정 (#10)

### DIFF
--- a/main.py
+++ b/main.py
@@ -269,29 +269,42 @@ async def websocket_endpoint(websocket: WebSocket, session_id: str):
 
 if __name__ == "__main__":
     import uvicorn
-    from pathlib import Path  # pathlib를 import합니다.
+    # from pathlib import Path  # pathlib를 import합니다.
 
     # 1. mkcert로 생성한 인증서의 절대 경로를 지정합니다.
     # (Python에서는 C:\certs\... 보다 C:/certs/... (슬래시)를 쓰는 것이 편합니다)
-    ssl_cert_path = Path("C:/certs/localhost+1.pem")
-    ssl_key_path = Path("C:/certs/localhost+1-key.pem")
+    # ssl_cert_path = Path("C:/certs/localhost+1.pem")
+    # ssl_key_path = Path("C:/certs/localhost+1-key.pem")
 
     # 2. 해당 경로에 mkcert 인증서 파일이 있는지 확인합니다.
-    if not ssl_cert_path.is_file() or not ssl_key_path.is_file():
-        print(f"[ERROR] mkcert SSL certificates not found at C:/certs/")
-        print("Check if 'localhost+1.pem' and 'localhost+1-key.pem' exist.")
-        print("Server cannot start with HTTPS.")
-    else:
-        print("[INFO] Starting server with mkcert HTTPS.")
-        uvicorn.run(
-            app,  # 'app' 변수는 이 파일 상단 어딘가에 정의되어 있어야 합니다.
+    # if not ssl_cert_path.is_file() or not ssl_key_path.is_file():
+    #     print(f"[ERROR] mkcert SSL certificates not found at C:/certs/")
+    #     print("Check if 'localhost+1.pem' and 'localhost+1-key.pem' exist.")
+    #     print("Server cannot start with HTTPS.")
+    # else:
+    #     print("[INFO] Starting server with mkcert HTTPS.")
+    #     uvicorn.run(
+    #         app,  # 'app' 변수는 이 파일 상단 어딘가에 정의되어 있어야 합니다.
+    #
+    #         # 3. host를 127.0.0.1로 변경합니다.
+    #         # (Vite 프록시가 127.0.0.1을 바라보고, mkcert 인증서도 localhost/127.0.0.1용입니다)
+    #         host="127.0.0.1",
+    #         port=8000,
+    #
+    #         # 4. mkcert 파일 경로를 문자열(str)로 전달합니다.
+    #         ssl_keyfile=str(ssl_key_path),
+    #         ssl_certfile=str(ssl_cert_path),
+    #     )
 
-            # 3. host를 127.0.0.1로 변경합니다.
-            # (Vite 프록시가 127.0.0.1을 바라보고, mkcert 인증서도 localhost/127.0.0.1용입니다)
-            host="127.0.0.1",
-            port=8000,
+    # 1. 이전 코드의 로컬 인증서 경로 설정 및 확인 로직을 제거합니다.
+    # 2. 서버를 HTTP 모드로 실행합니다.
+    print("[INFO] Starting server with HTTP (for Docker/ALB environment).")
 
-            # 4. mkcert 파일 경로를 문자열(str)로 전달합니다.
-            ssl_keyfile=str(ssl_key_path),
-            ssl_certfile=str(ssl_cert_path),
-        )
+    # [수정] host="127.0.0.1" -> host="0.0.0.0" 으로 변경하여 외부 접근을 허용합니다.
+    uvicorn.run(
+        app,
+        host="0.0.0.0",
+        port=8000,
+        # ssl_keyfile과 ssl_certfile 인수를 제거합니다.
+        # (제거된 부분: ssl_keyfile=str(ssl_key_path), ssl_certfile=str(ssl_cert_path))
+    )


### PR DESCRIPTION
# Pull Request
> 제목 규칙: **[타입]: 상세 내용 (#이슈번호)** 예: [Feat]: 로그인 기능 구현 (#12)

## PR 유형 (Type of PR)
> 해당하는 항목에 `x` 표기해주세요. (선택된 항목은 자동 라벨링됩니다)
- [ ] 기능 (Feature)
- [ ] 버그 수정 (Bugfix)
- [ ] 기능 개선 (Enhancement)
- [ ] 리팩토링 (Refactoring)
- [ ] 문서 (Docs)
- [x] 기타 (Chore)

---

## PR 요약 (PR Summary)
> 이 PR이 무엇을 하는지 한눈에 파악할 수 있도록 핵심 내용을 요약합니다.

로드 밸런서(ALB) 환경에 맞추어 **로컬 개발용 임시 HTTPS/SSL 설정**을 제거하고, 서버 실행 호스트를 **`127.0.0.1`에서 `0.0.0.0`**으로 변경하여 HTTP 통신을 기본으로 설정합니다.

---

## 관련 이슈 (Related Issue)
> 이 PR과 관련된 이슈 번호를 작성해주세요.
> (예: Closes #10, Fixes #11, Resolves #12, Relates to #13)

- Closes #10 

---

## 변경 사항 (Changes)
> 이 PR로 인해 변경된 점을 상세히 서술합니다.

**1. 서버 실행 설정 파일 (`main.py`) 수정**

* **HTTPS 관련 설정 제거:** `uvicorn.run()` 호출 시, 로컬 인증서 경로를 지정하는 **`ssl_keyfile` 및 `ssl_certfile` 인수를 제거**하여 서버를 HTTP 모드로 실행하도록 변경했습니다. (주석 처리된 HTTPS 로직도 제거)
* **호스트 변경:** 서버 바인딩 호스트를 `host="127.0.0.1"`에서 **`host="0.0.0.0"`**으로 변경하여 도커 및 로드 밸런서 환경에서 모든 네트워크 인터페이스를 통해 접근 가능하도록 설정했습니다.

**2. (선택 사항) 관련 설정 파일 정리**

* (예: Spring, Django 등 다른 설정이 있다면) 로컬 환경에서 HTTPS를 강제하던 설정이나 리다이렉션 로직이 있다면 제거합니다.

---

## 스크린샷 (Screenshots) (Optional)
> UI/UX 변경 사항이 있다면, 변경 전후 스크린샷을 첨부해주세요.

(여기에 파일 첨부)

---

## 테스트 방법 (Test Steps)
> 리뷰어가 이 변경 사항을 로컬에서 직접 검증할 수 있도록 구체적인 절차를 작성해주세요.

1.  로컬 환경에서 서버를 실행합니다. (`bootRun` 또는 `python main.py` 등 해당 실행 명령어)
2.  서버 콘솔 로그에 HTTPS 관련 오류 없이 **HTTP 모드 실행 로그**가 정상적으로 출력되는지 확인합니다.
3.  브라우저나 API 클라이언트(Postman 등)를 사용하여 `http://127.0.0.1:8000/` (혹은 설정된 포트)로 접근했을 때, **HTTPS로 강제 리다이렉션되지 않고** HTTP로 정상적인 응답이 오는지 확인합니다.

---

## 셀프 체크리스트 (Self-Checklist)
> 리뷰 요청 전, 아래 항목을 확인해주세요.
- [x] 제목 규칙을 지켰습니다.
- [ ] 관련 이슈를 연결했습니다.
- [x] 로컬에서 충분히 테스트했습니다. (HTTP 통신 확인)
- [ ] `dev` 브랜치를 Pull하여 최신 코드를 반영했습니다.
- [ ] CI/CD 파이프라인이 통과했습니다.

---

## 리뷰어에게 (To Reviewers)
> 리뷰어가 특별히 더 신경 써서 봐야 할 부분이나 참고사항을 작성해주세요.
> (예: 성능 최적화 부분 집중 검토 필요, API 스펙 변경 사항 확인 요청 등)

이 PR은 로드 밸런서 도입 환경에 맞춰 기존의 임시 로컬 HTTPS 설정을 정리하는 작업입니다. 특히, 서버가 **HTTP로만** 실행되는 것을 확인해 주시면 됩니다.
`host="0.0.0.0"` 변경으로 인해 예상치 못한 로컬 환경 문제가 발생하지 않는지 확인 부탁드립니다.